### PR TITLE
Proper error return in coord_check.py

### DIFF
--- a/mup/coord_check.py
+++ b/mup/coord_check.py
@@ -142,6 +142,8 @@ def _record_coords(records, width, modulename, t,
                 for fname, f in fdict.items():
                     _d[fname] = f(x).item()
                 records.append(_d)
+            elif x is None:
+                pass
             else:
                 raise NotImplementedError(f'Unexpected output type: {type(x)}')
         with torch.no_grad():

--- a/mup/coord_check.py
+++ b/mup/coord_check.py
@@ -143,7 +143,7 @@ def _record_coords(records, width, modulename, t,
                     _d[fname] = f(x).item()
                 records.append(_d)
             else:
-                raise NotImplemented(f'Unexpected output type: {type(x)}')
+                raise NotImplementedError(f'Unexpected output type: {type(x)}')
         with torch.no_grad():
             ret = {
                 'width': width,
@@ -168,7 +168,7 @@ def _record_coords(records, width, modulename, t,
                     _ret[fname] = f(output).item()
                 records.append(_ret)
             else:
-                raise NotImplemented(f'Unexpected output type: {type(output)}')
+                raise NotImplementedError(f'Unexpected output type: {type(output)}')
 
             # input stats
             if input_fdict:
@@ -188,7 +188,7 @@ def _record_coords(records, width, modulename, t,
                         _ret[fname] = f(input).item()
                     records.append(_ret)
                 else:
-                    raise NotImplemented(f'Unexpected output type: {type(input)}')
+                    raise NotImplementedError(f'Unexpected output type: {type(input)}')
 
             # param stats
             if param_fdict:


### PR DESCRIPTION
Super small bug fix - `NotImplementedError` is what you want to properly raise this error and give the type to the user