### PR TITLE
fix: dtype for newer torch versions

### DIFF
--- a/mup/coord_check.py
+++ b/mup/coord_check.py
@@ -41,14 +41,14 @@ def covoffdiag(x):
 
 #: dict of provided functions for use in coord check
 FDICT = {
-    'l1': lambda x: torch.abs(x).mean(),
-    'l2': lambda x: (x**2).mean()**0.5,
-    'mean': lambda x: x.mean(),
-    'std': lambda x: x.std(),
-    'covl1': lambda x: torch.abs(cov(x)).mean(),
-    'covl2': lambda x: (cov(x)**2).mean()**0.5,
-    'covoffdiagl1': lambda x: torch.abs(covoffdiag(x)).mean(),
-    'covoffdiagl2': lambda x: (covoffdiag(x)**2).mean()**0.5
+    'l1': lambda x: torch.abs(x).mean(dtype=torch.float32),
+    'l2': lambda x: (x**2).mean(dtype=torch.float32)**0.5,
+    'mean': lambda x: x.mean(dtype=torch.float32),
+    'std': lambda x: x.std(dtype=torch.float32),
+    'covl1': lambda x: torch.abs(cov(x)).mean(dtype=torch.float32),
+    'covl2': lambda x: (cov(x)**2).mean(dtype=torch.float32)**0.5,
+    'covoffdiagl1': lambda x: torch.abs(covoffdiag(x)).mean(dtype=torch.float32),
+    'covoffdiagl2': lambda x: (covoffdiag(x)**2).mean(dtype=torch.float32)**0.5
 }
 
 def convert_fdict(d):


### PR DESCRIPTION
Since torch 1.10, [torch.mean](https://pytorch.org/docs/1.10/generated/torch.mean.html?highlight=torch%20mean#torch.mean) will try to infer the dtype if none is supplied. However, if you use it with an input that is of type long (i.e. a tensor of token ids), we get the following error

`RuntimeError: mean(): could not infer output dtype. Input dtype must be either a floating point or complex dtype. Got: Long`