### PR TITLE
Allowing users to create their own shapes

### DIFF
--- a/mup/shape.py
+++ b/mup/shape.py
@@ -16,6 +16,9 @@ __BSH_COMMENT__ = '''\
 '''
 
 def get_shapes(model):
+    # If you want to implement a custom shapes function, you can use this name
+    if hasattr(model, "get_shapes"):
+        return model.get_shapes()
     return {name: param.shape for name, param in model.named_parameters()}
 
 def get_infshapes(model):


### PR DESCRIPTION
This feature is needed for users that want to define the `get_shapes` function themselves, for example in tensor-parallel environments where each process only sees a fraction of the parameters.