### PR TITLE
coord check plot improvements

### DIFF
--- a/mup/coord_check.py
+++ b/mup/coord_check.py
@@ -490,10 +490,8 @@ def plot_coord_data(df, y='l1', save_to=None, suptitle=None, x='width', hue='mod
             the column of `df` to represent as color. Default: `'module'`
         legend:
             'auto', 'brief', 'full', or False. This is passed to `seaborn.lineplot`.
-        name_contains:
-            only plot modules whose name contains `name_contains`, intersection with `name_not_contains`
-        name_not_contains:
-            only plot modules whose name does not contain `name_not_contains`, intersection with `name_contains`
+        name_contains, name_not_contains:
+            only plot modules whose name contains `name_contains` and does not contain `name_not_contains`
         module_list:
             only plot modules that are given in the list, overrides `name_contains` and `name_not_contains`
         loglog:

--- a/mup/coord_check.py
+++ b/mup/coord_check.py
@@ -549,8 +549,6 @@ def plot_coord_data(df, y='l1', save_to=None, suptitle=None, x='width', hue='mod
         plt.title(f't={t}')
         if t != 1:
             plt.ylabel('')
-        else:
-            plt.legend(labels=hue_order, bbox_to_anchor=(0, 1), loc="upper right")
         if loglog:
             plt.loglog(base=logbase)
         ax = plt.gca()


### PR DESCRIPTION
This ports a few changes I made in order to visualize the coord check plots when integrating mup into Megatron-Deepspeed:

- you can specify name_contains and name_not_contains simultaneously (it'll do a logical AND)
- you can directly specify the module list you want to see
- the orders of hues is in alphabetical list of module names, which will follow the layer number for sequential models
- the y axis will be the same for every plot, allowing better inspection of the divergence across time steps if it happens.