### PR TITLE
add width_mult to optimizer dict

### DIFF
--- a/mup/optim.py
+++ b/mup/optim.py
@@ -75,6 +75,7 @@ def MuAdam(params, impl=Adam, decoupled_wd=False, **kwargs):
         for width_mult, group in matrix_like_p.items():
             # Scale learning rate and weight decay accordingly
             group['lr'] /= width_mult
+            group['width_mult'] = width_mult
             if not decoupled_wd:
                 group['weight_decay'] *= width_mult
         new_param_groups.extend(list(matrix_like_p.values()) + [vector_like_p])


### PR DESCRIPTION
Adding the `width_mult` key to the MuAdam state dictionary to make it more easy to use the class, e.g. to enable its correct use in https://github.com/EleutherAI/gpt-neox