### PR TITLE
Refactor: Addressing Sources of User Error

### DIFF
--- a/mup/__init__.py
+++ b/mup/__init__.py
@@ -4,4 +4,4 @@ from mup.shape import *
 from mup.infshape import *
 from mup.init import *
 from mup.layer import *
-from mup.optim import *
+from mup.optim import MuSGD, MuAdam, MuAdamW, process_param_groups

--- a/mup/optim.py
+++ b/mup/optim.py
@@ -23,6 +23,8 @@ from collections import defaultdict
 
 from torch.optim import SGD, Adam, AdamW
 
+import logging
+logger = logging.getLogger(__name__)
 
 def process_param_groups(params, **kwargs):
     param_groups = list(params)
@@ -51,6 +53,9 @@ def MuAdam(params, impl=Adam, decoupled_wd=False, **kwargs):
         An instance of `impl` with refined parameter groups, each of which has the correctly
         scaled learning rate according to mup.
     '''
+    if impl == Adam and kwargs.get('weight_decay', False):
+        logger.warning('MuAdam does not scale weight decay correctly. Use MuAdamW instead.')
+
     new_param_groups = []
     for param_group in process_param_groups(params, **kwargs):
         # For every existing param group, we split into several new groups


### PR DESCRIPTION
I made two changes which should help future users implement MuP correctly:

Previously a user could use mup.Adam, mup.AdamW, or mup.SGD (which are just the regular PyTorch optimizers) instead of the correct mup.MuAdam, mup.MuAdamW, or mup.MuSGD. Now the vanilla PyTorch optimizers cannot be accidentally accessed through the mup package.

If mup.MuAdam is used with weight decay, a warning will prompt the user to switch to mup.MuAdamW for correct weight decay scaling as described in appendix B.3 of the version of the paper which is on ArXiv. Note that doing a coord check will not indicate an incorrect implementation when using MuAdam with weight decay, but increasing model size will still eventually lead to diminishing performance unless MuAdamW is used instead (in my experience).
