### PR TITLE
Add support for dataclasses

### DIFF
--- a/mup/coord_check.py
+++ b/mup/coord_check.py
@@ -159,8 +159,9 @@ def _record_coords(records, width, modulename, t,
             get_stat(d, output, output_fdict)
 
             # input stats
-            d = {'width': width, 'module': modulename + ':in', 't': t}
-            get_stat(d, input, input_fdict)
+            if input_fdict:
+                d = {'width': width, 'module': modulename + ':in', 't': t}
+                get_stat(d, input, input_fdict)
 
             # param stats
             if param_fdict:


### PR DESCRIPTION
This PR closes #80. It adds support for [dataclasses](https://docs.python.org/3/library/dataclasses.html) in `get_coord_data`.

cc @thegregyang @edwardjhu